### PR TITLE
Resolved control permission

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+ComposeFloatingWindow

--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="tabSettings">
+      <map>
+        <entry key="Firebase Crashlytics">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="PLACEHOLDER" />
+                  <option name="mobileSdkAppId" value="" />
+                  <option name="projectId" value="" />
+                  <option name="projectNumber" value="" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="THIRTY_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <value>
+      <entry key="app">
+        <State />
+      </entry>
+    </value>
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,10 +4,8 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -15,6 +13,7 @@
             <option value="$PROJECT_DIR$/library" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,32 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.10" />
+    <option name="version" value="1.9.10" />
   </component>
 </project>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace = "com.github.only52607.compose.window"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.github.only52607.compose.window"
         minSdk = 24
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
 
@@ -30,17 +30,17 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.3"
     }
     packaging {
         resources {
@@ -55,7 +55,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
     implementation("androidx.activity:activity-compose:1.7.2")
-    implementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    implementation(platform("androidx.compose:compose-bom:2024.02.02"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
@@ -63,7 +63,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.02.02"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/src/main/java/com/github/only52607/compose/window/MainActivity.kt
+++ b/app/src/main/java/com/github/only52607/compose/window/MainActivity.kt
@@ -12,19 +12,26 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.github.only52607.compose.window.ui.DialogPermission
 import com.github.only52607.compose.window.ui.FloatingWindowContent
 import com.github.only52607.compose.window.ui.theme.ComposeFloatingWindowTheme
 
 class MainActivity : ComponentActivity() {
-    private lateinit var floatingWindow: ComposeFloatingWindow
+
+    private val floatingWindow by lazy {
+        createFloatingWindow()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             ComposeFloatingWindowTheme {
+                val showDialogPermission = remember { mutableStateOf(false) }
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
@@ -35,7 +42,11 @@ class MainActivity : ComponentActivity() {
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Button(onClick = {
-                            show()
+                            if (floatingWindow.isAvailable()) {
+                                show()
+                            } else {
+                                showDialogPermission.value = true
+                            }
                         }) {
                             Text("Show")
                         }
@@ -46,27 +57,24 @@ class MainActivity : ComponentActivity() {
                             Text("Hide")
                         }
                     }
+                    DialogPermission(showDialogState = showDialogPermission)
                 }
             }
         }
     }
 
-    private fun createFloatingWindow() {
-        floatingWindow = ComposeFloatingWindow(applicationContext)
-        floatingWindow.setContent {
-            FloatingWindowContent()
+    private fun createFloatingWindow(): ComposeFloatingWindow =
+        ComposeFloatingWindow(applicationContext).apply {
+            setContent {
+                FloatingWindowContent()
+            }
         }
-    }
 
     private fun show() {
-        if (!::floatingWindow.isInitialized) {
-            createFloatingWindow()
-        }
         floatingWindow.show()
     }
 
     private fun hide() {
-        if (!::floatingWindow.isInitialized) return
         floatingWindow.hide()
     }
 }

--- a/app/src/main/java/com/github/only52607/compose/window/ui/DialogPermission.kt
+++ b/app/src/main/java/com/github/only52607/compose/window/ui/DialogPermission.kt
@@ -1,0 +1,73 @@
+package com.github.only52607.compose.window.ui
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.github.only52607.compose.window.R
+
+@Composable
+fun DialogPermission(
+    showDialogState: MutableState<Boolean> = mutableStateOf(false),
+    permission: String = Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+    onDismiss: () -> Unit = { }
+) {
+    var showDialogPermission by remember { showDialogState }
+    val context = LocalContext.current
+    if(showDialogPermission.not()) return
+    AlertDialog(
+        icon = {
+            Icon(Icons.Default.Warning, contentDescription = stringResource(R.string.permission_required))
+        },
+        title = {
+            Text(text = stringResource(id = R.string.permission_required))
+        },
+        text = {
+            Text(text = stringResource(R.string.message_permission_to_draw_on_top_others_apps))
+        },
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    showDialogPermission = false
+                    context.requestPermission(permission)
+                }
+            ) {
+                Text(stringResource(R.string.grant_permission))
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = {
+                    showDialogPermission = false
+                }
+            ) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}
+
+private fun Context.requestPermission(permission: String) {
+    startActivity(
+        Intent(
+            permission,
+        Uri.parse("package:$packageName")
+    ).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    })
+}

--- a/app/src/main/java/com/github/only52607/compose/window/ui/FloatingWindowContent.kt
+++ b/app/src/main/java/com/github/only52607/compose/window/ui/FloatingWindowContent.kt
@@ -10,12 +10,14 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.github.only52607.compose.window.LocalFloatingWindow
 import com.github.only52607.compose.window.dragFloatingWindow
 
 @Composable
 fun FloatingWindowContent(
     model: FloatingWindowViewModel = viewModel()
 ) {
+    val floatingWindow = LocalFloatingWindow.current
     if (model.dialogVisible) {
         SystemAlertDialog(
             onDismissRequest = { model.dismissDialog() },
@@ -32,7 +34,7 @@ fun FloatingWindowContent(
     FloatingActionButton(
         modifier = Modifier.dragFloatingWindow(),
         onClick = {
-            model.showDialog()
+            floatingWindow.hide()
         }) {
         Icon(Icons.Filled.Call, "Call")
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">ComposeFloatingWindow</string>
+    <string name="permission_required">Permission required</string>
+    <string name="grant_permission">Grant permission</string>
+    <string name="cancel">Cancel</string>
+    <string name="message_permission_to_draw_on_top_others_apps">…to show floating windows the app needs permissions to draw on top of other apps</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.10" apply false
-    id("com.android.library") version "8.1.1" apply false
+    id("com.android.application") version "8.3.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
+    id("com.android.library") version "8.3.2" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Sep 17 10:22:18 CST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "com.github.only52607.compose.window"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 24
@@ -25,14 +25,14 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.3"
     }
     buildFeatures {
         compose = true
@@ -48,12 +48,12 @@ android {
 version = 1.0
 
 dependencies {
-    implementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    implementation(platform("androidx.compose:compose-bom:2024.02.02"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.02.02"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/library/src/main/java/androidx/compose/material3/AndroidSystemAlertDialog.kt
+++ b/library/src/main/java/androidx/compose/material3/AndroidSystemAlertDialog.kt
@@ -17,8 +17,10 @@
 @file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
 package androidx.compose.material3
 
+import androidx.compose.material3.tokens.ColorSchemeKeyTokens
 import androidx.compose.material3.tokens.DialogTokens
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
@@ -124,5 +126,11 @@ fun SystemAlertDialog(
     }
 }
 
+/** Converts a color token key to the local color scheme provided by the theme */
+@ReadOnlyComposable
+@Composable
+internal fun ColorSchemeKeyTokens.toColor(): Color {
+    return MaterialTheme.colorScheme.fromToken(this)
+}
 private val ButtonsMainAxisSpacing = 8.dp
 private val ButtonsCrossAxisSpacing = 12.dp

--- a/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/java/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.Context
 import android.graphics.PixelFormat
 import android.os.Build
+import android.provider.Settings
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -38,7 +39,7 @@ import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import kotlinx.coroutines.launch
 
 class ComposeFloatingWindow(
-    val context: Context
+    private val context: Context
 ) : SavedStateRegistryOwner, ViewModelStoreOwner, HasDefaultViewModelProviderFactory {
 
     override val defaultViewModelProviderFactory: ViewModelProvider.Factory by lazy {
@@ -111,6 +112,7 @@ class ComposeFloatingWindow(
     }
 
     fun show() {
+        if(isAvailable().not()) return
         require(decorView.childCount != 0) {
             "Content view cannot be empty"
         }
@@ -139,13 +141,13 @@ class ComposeFloatingWindow(
     }
 
     fun hide() {
-        if (!showing) {
-            return
-        }
+        if (!showing) return
         showing = false
         windowManager.removeViewImmediate(decorView)
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
     }
+
+    fun isAvailable(): Boolean = Settings.canDrawOverlays(context)
 
     init {
         savedStateRegistryController.performRestore(null)


### PR DESCRIPTION
Hi 🤗, My name is Kevin, I was looking for a library for my free app and I like this library, I would like to help in its construction. This PR that solves the problem when the app does not have permission to draw on other apps ([issue reported](https://github.com/only52607/compose-floating-window/issues/1)), this permission is necessary to be able to show **ComposeFloatingWindow**, the solution is simple, **ComposeFloatingWindow** exposes the `isAvailable()` method to validate the permission , this method can be used externally to query its availability before displaying a **ComposeFloatingWindow**. This solution has examples where you can see the real use of `isAvailable()`. Thank you very much, I hope you like this solution🤖

Tests
| Before  | After |
| ------------- | ------------- |
| ![fix_permission_draw_top](https://github.com/only52607/compose-floating-window/assets/11259032/18a6df70-51c9-4c84-bd7d-768a1ee1350e)|![control_permission](https://github.com/only52607/compose-floating-window/assets/11259032/a5a7f2cc-cea4-4e2c-b5af-c7d065959f4c)|


🥳 This solution allows permission control without the app breaking the user